### PR TITLE
Expose panic formatting as function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0/MIT"
 name = "console_error_panic_hook"
 readme = "./README.md"
 repository = "https://github.com/rustwasm/console_error_panic_hook"
-version = "0.1.6"
+version = "0.1.7"
 
 [badges]
 travis-ci = { repository = "rustwasm/console_error_panic_hook" }


### PR DESCRIPTION
Enso developers would like to implement a panic hook that writes to `console.error`, but also uses an application-specific API to write the panic info to the console running the program as an electron app. The latter is straightforward enough, but `console_error_panic_hook`'s formatting addresses browser subtleties, and we'd prefer not to duplicate that.

This PR exposes panic formatting in the API, for use from custom panic hooks.